### PR TITLE
fixes to xslt stylesheets

### DIFF
--- a/service/models/xslt.py
+++ b/service/models/xslt.py
@@ -1369,10 +1369,12 @@ class XSLT(object):
                 <xsl:attribute name="email"><xsl:value-of select=".//email"/></xsl:attribute>
               </xsl:if>
               <xsl:if test="contains(contrib-id/@contrib-id-type,'orcid')">
-              <identifier>
-                <xsl:attribute name="type"><xsl:text>orcid</xsl:text></xsl:attribute>
-                <xsl:copy-of select="contrib-id[@contrib-id-type='orcid']/text()"/>
-              </identifier>
+              <identifiers>
+                <identifier>
+                  <xsl:attribute name="type"><xsl:text>orcid</xsl:text></xsl:attribute>
+                  <xsl:copy-of select="contrib-id[@contrib-id-type='orcid']/text()"/>
+                </identifier>
+              </identifiers>
               </xsl:if>
             </person>
           </xsl:for-each>

--- a/service/models/xslt.py
+++ b/service/models/xslt.py
@@ -1298,12 +1298,12 @@ class XSLT(object):
       <titlesMain>
           <titleMain>
             <xsl:attribute name="language"><xsl:value-of select="$langOut"/></xsl:attribute>
-            <xsl:value-of select="//article-meta/title-group/article-title"/>
+            <xsl:value-of select="normalize-space(//article-meta/title-group/article-title)"/>
           </titleMain>
           <xsl:for-each select="//article-meta/title-group/trans-title-group/trans-title">
             <titleMain>
               <xsl:call-template name="insert-lang-attribute"/>
-              <xsl:value-of select="."/>
+              <xsl:value-of select="normalize-space()"/>
             </titleMain>
           </xsl:for-each>
       </titlesMain>
@@ -1312,7 +1312,21 @@ class XSLT(object):
             <title> 
               <xsl:attribute name="language"><xsl:value-of select="$langOut"/></xsl:attribute>
               <xsl:attribute name="type"><xsl:text>parent</xsl:text></xsl:attribute> 
-              <xsl:value-of select="normalize-space(text())"/>
+              <xsl:value-of select="normalize-space()"/>
+            </title>
+          </xsl:for-each>
+          <xsl:if test="//article-meta/title-group/subtitle">
+            <title>
+              <xsl:attribute name="language"><xsl:value-of select="$langOut"/></xsl:attribute>
+              <xsl:attribute name="type"><xsl:text>sub</xsl:text></xsl:attribute>
+              <xsl:value-of select="normalize-space(//article-meta/title-group/subtitle)"/>
+            </title>
+          </xsl:if>
+          <xsl:for-each select="//article-meta/title-group/trans-title-group/trans-subtitle">
+            <title>
+              <xsl:call-template name="insert-lang-attribute"/>
+              <xsl:attribute name="type"><xsl:text>sub</xsl:text></xsl:attribute>
+              <xsl:value-of select="normalize-space()"/>
             </title>
           </xsl:for-each>
       </titles>
@@ -1329,7 +1343,7 @@ class XSLT(object):
             <abstract>
               <xsl:call-template name="insert-lang-attribute"/>
               <xsl:text disable-output-escaping="yes">&lt;![CDATA[</xsl:text>
-              <xsl:copy-of select="//article-meta/trans-abstract/*" disable-output-escaping="yes" />
+              <xsl:copy-of select="./*" disable-output-escaping="yes" />
               <xsl:text disable-output-escaping="yes">]]&gt;</xsl:text>
             </abstract>
           </xsl:for-each>
@@ -2333,9 +2347,7 @@ class XSLT(object):
             </xsl:for-each>
             <xsl:for-each select="//article-meta/trans-abstract">
               <mods:abstract>
-                <xsl:if test="@xml:lang">
-                  <xsl:attribute name="language"><xsl:value-of select="@xml:lang"/></xsl:attribute>
-                </xsl:if>
+                <xsl:call-template name="insert-lang-attribute"/>
                 <xsl:text disable-output-escaping="yes">&lt;![CDATA[</xsl:text>
                 <xsl:copy-of select="./*" disable-output-escaping="yes" />
                 <xsl:text disable-output-escaping="yes">]]&gt;</xsl:text>
@@ -2345,7 +2357,10 @@ class XSLT(object):
             <xsl:if test="//article-meta/kwd-group/kwd">
                 <mods:subject>
                     <xsl:for-each select="//article-meta/kwd-group/kwd">
-                        <mods:topic><xsl:value-of select="."/></mods:topic>
+                        <mods:topic>
+                          <xsl:call-template name="insert-lang-attribute"/>
+                          <xsl:value-of select="."/>
+                        </mods:topic>
                     </xsl:for-each>
                 </mods:subject>
             </xsl:if>

--- a/service/models/xslt.py
+++ b/service/models/xslt.py
@@ -1302,9 +1302,7 @@ class XSLT(object):
           </titleMain>
           <xsl:for-each select="//article-meta/title-group/trans-title-group/trans-title">
             <titleMain>
-              <xsl:if test="@xml:lang">
-                <xsl:attribute name="language"><xsl:value-of select="@xml:lang"/></xsl:attribute>
-              </xsl:if>
+              <xsl:call-template name="insert-lang-attribute"/>
               <xsl:value-of select="."/>
             </titleMain>
           </xsl:for-each>
@@ -1329,9 +1327,7 @@ class XSLT(object):
           </xsl:if>
           <xsl:for-each select="//article-meta/trans-abstract">
             <abstract>
-              <xsl:if test="@xml:lang">
-                <xsl:attribute name="language"><xsl:value-of select="@xml:lang"/></xsl:attribute>
-              </xsl:if>
+              <xsl:call-template name="insert-lang-attribute"/>
               <xsl:text disable-output-escaping="yes">&lt;![CDATA[</xsl:text>
               <xsl:copy-of select="//article-meta/trans-abstract/*" disable-output-escaping="yes" />
               <xsl:text disable-output-escaping="yes">]]&gt;</xsl:text>
@@ -1388,7 +1384,7 @@ class XSLT(object):
           <xsl:for-each select="//article-meta/kwd-group/kwd">
             <xsl:if test="string-length(normalize-space(text()))>0">
               <keyword> 
-                <xsl:attribute name="language"><xsl:value-of select="$langOut"/></xsl:attribute>
+                <xsl:call-template name="insert-lang-attribute"/>
                 <xsl:attribute name="type"><xsl:text>uncontrolled</xsl:text></xsl:attribute>
                 <xsl:value-of select="normalize-space(text())"/>
               </keyword>
@@ -1549,6 +1545,25 @@ class XSLT(object):
              </xsl:attribute>
           </date>
   </xsl:template>
+  
+  <xsl:template name="insert-lang-attribute">
+    <xsl:choose>
+        <xsl:when test="@xml:lang">
+            <xsl:variable name="lang2" select="translate(@xml:lang,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz')"/>
+            <xsl:variable name="lang3" select="document('')//langCodeMap/langCodes[@iso639-1=$lang2]/@iso639-2"/>
+            <xsl:attribute name="language"><xsl:value-of select="$lang3"/></xsl:attribute>
+        </xsl:when>
+        <xsl:when test="../@xml:lang">
+            <xsl:variable name="lang2" select="translate(../@xml:lang,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz')"/>
+            <xsl:variable name="lang3" select="document('')//langCodeMap/langCodes[@iso639-1=$lang2]/@iso639-2"/>
+            <xsl:attribute name="language"><xsl:value-of select="$lang3"/></xsl:attribute>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:attribute name="language"><xsl:value-of select="$langOut"/></xsl:attribute>
+        </xsl:otherwise>
+        </xsl:choose>
+  </xsl:template>
+  
 
 </xsl:stylesheet>
 '''.format(xmlinject=iso639codes)
@@ -2409,9 +2424,14 @@ class XSLT(object):
     </xsl:template>
 
     <xsl:template name="insert-lang-attribute">
-        <xsl:if test="@xml:lang">
+        <xsl:choose>
+        <xsl:when test="@xml:lang">
             <xsl:attribute name="xml:lang"><xsl:value-of select="@xml:lang"/></xsl:attribute>
-        </xsl:if>
+        </xsl:when>
+        <xsl:when test="../@xml:lang">
+            <xsl:attribute name="xml:lang"><xsl:value-of select="../@xml:lang"/></xsl:attribute>
+        </xsl:when>
+        </xsl:choose>
     </xsl:template>
 
 </xsl:stylesheet>

--- a/service/models/xslt.py
+++ b/service/models/xslt.py
@@ -1365,12 +1365,15 @@ class XSLT(object):
                 <identifier type="gnd|intern">?????</identifier>
               </identifiers>
               -->
-              <xsl:if test="contains(contrib-id/@contrib-id-type,'orcid')">
-                <xsl:attribute name="orcid">
-                  <xsl:copy-of select="contrib-id[@contrib-id-type='orcid']/text()"/>
-                </xsl:attribute>
+              <xsl:if test=".//email">
+                <xsl:attribute name="email"><xsl:value-of select=".//email"/></xsl:attribute>
               </xsl:if>
-              <xsl:attribute name="email"><xsl:value-of select=".//email"/></xsl:attribute>  
+              <xsl:if test="contains(contrib-id/@contrib-id-type,'orcid')">
+              <identifier>
+                <xsl:attribute name="type"><xsl:text>orcid</xsl:text></xsl:attribute>
+                <xsl:copy-of select="contrib-id[@contrib-id-type='orcid']/text()"/>
+              </identifier>
+              </xsl:if>
             </person>
           </xsl:for-each>
       </persons>
@@ -2233,18 +2236,18 @@ class XSLT(object):
                             <mods:number><xsl:value-of select="//article-meta/issue"/></mods:number>
                         </mods:detail>
                     </xsl:if>
-                    <xsl:if test="//article-meta/fpage">
+                    <xsl:if test="//article-meta/fpage or //article-meta/counts/page-count/@count">
                         <mods:extent unit="pages">
-                            <mods:start><xsl:value-of select="//article-meta/fpage"/></mods:start>
+                            <xsl:if test="//article-meta/fpage">
+                                <mods:start><xsl:value-of select="//article-meta/fpage"/></mods:start>
+                            </xsl:if>
                             <xsl:if test="//article-meta/lpage">
                                 <mods:end><xsl:value-of select="//article-meta/lpage"/></mods:end>
                             </xsl:if>
+                            <xsl:if test="//article-meta/counts/page-count/@count">
+                                <mods:total><xsl:value-of select="//article-meta/counts/page-count/@count"/></mods:total>
+                            </xsl:if>
                         </mods:extent>
-                    </xsl:if>
-                    <xsl:if test="//article-meta/counts/page-count/@count">
-                      <mods:extent unit="pages">
-                        <mods:total><xsl:value-of select="//article-meta/counts/page-count/@count"/></mods:total>
-                      </mods:extent>
                     </xsl:if>
                 </mods:part>
             </mods:relatedItem>


### PR DESCRIPTION
fixed wrong orcid inclusion in jats2opus4:
The ORCID identifier is now correctly displayed as an `<identifier type="orcid">` subelement to `<person>` instead of as an attribute to `<person>`.

cosmetic changes:
1. in jats2opus4: email attribute is now only added if an email element actually exists.
2. in jats2metsmods: pagecount is now part of the same `<mods:extent unit="pages">` element as the first and last page. expanded on existing nested structure: if either //article-meta/fpage or //article-meta/counts/page-count/@count exist, a `<mods:extent unit="pages">` element is generated which can contain first page, last page, and page count.