### PR TITLE
Added method to delete old sword logs with schedule

### DIFF
--- a/service/dao.py
+++ b/service/dao.py
@@ -754,6 +754,12 @@ class RepositoryDepositLogDAO(dao.ESDAO):
         obs = cls.query(q=q.get_deposit_dates_query(repo_id))
         return obs
 
+    @classmethod
+    def pull_old_deposit_logs(cls, repo_id, to_date):
+        """Get all deposit logs older than the specified date"""
+        q = RepositoryDepositLogQuery()
+        obs = cls.query(q=q.get_old_logs_query(to_date, repo_id))
+        return obs
 
 class RepositoryDepositLogQuery(object):
     """
@@ -862,6 +868,27 @@ class RepositoryDepositLogQuery(object):
             "size": 1,
             "sort": {"last_updated": {"order": "desc"}}
         }
+
+    def get_old_logs_query(self, to_date, repo_id=None):
+        query = {
+            "query": {
+                "bool": {
+                    "must": [{
+                        "range": {
+                            "last_updated": {
+                                "lt": to_date
+                            }
+                        }
+                    }]
+
+                }
+            },
+            "sort": {"last_updated": {"order": "desc"}},
+            "size": 10000
+        }
+        if repo_id:
+            query['query']['bool']['must'].append({ "term": {"repo.exact": repo_id}})
+        return query
 
 
 class LicenseManagementDAO(dao.ESDAO):

--- a/service/lib/cleanup_repository_logs.py
+++ b/service/lib/cleanup_repository_logs.py
@@ -28,10 +28,3 @@ def cleanup_repository_logs():
             deposit_log = RepositoryDepositLog().pull(log['id'])
             deposit_log.delete()
             app.looger.debug(f"Deleted sword deposit log {log['id']}")
-
-
-
-
-
-
-

--- a/service/lib/cleanup_repository_logs.py
+++ b/service/lib/cleanup_repository_logs.py
@@ -1,0 +1,37 @@
+from service.models import Account, RepositoryDepositLog, DepositRecord
+from dateutil.relativedelta import relativedelta
+from octopus.core import app
+from octopus.lib import dates
+
+def cleanup_repository_logs():
+    bibids = Account.pull_all_repositories()
+    for bibid in bibids:
+        repo_id = bibids[bibid]
+        # pull the latest sword repository deposit log
+        latest_log = RepositoryDepositLog().pull_by_repo(repo_id)
+        if not latest_log:
+            continue
+        # Get the date to keep logs from
+        last_updated = dates.parse(latest_log.last_updated)
+        keep = app.config.get('SCHEDULE_KEEP_SWORD_LOGS_MONTHS', 3)
+        keep_date = (last_updated - relativedelta(months=keep)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        # Get all sword repository deposit logs older than keep_date
+        old_logs = RepositoryDepositLog().pull_old_deposit_logs(repo_id, keep_date)
+        for log in old_logs.get('hits', {}).get('hits', []):
+            deposit_record_logs.append(log['id'])
+            messages = log.get('_source', {}).get('messages', [])
+            for msg in messages:
+                if msg.get('deposit_record', None) and msg['deposit_record'] != "None":
+                    detailed_log = DepositRecord.pull(msg['deposit_record'])
+                    detailed_log.delete()
+                    app.looger.debug(f"Deleted sword deposit record {msg['deposit_record']}")
+            deposit_log = RepositoryDepositLog().pull(log['id'])
+            deposit_log.delete()
+            app.looger.debug(f"Deleted sword deposit log {log['id']}")
+
+
+
+
+
+
+

--- a/service/scheduler.py
+++ b/service/scheduler.py
@@ -25,6 +25,7 @@ from threading import Thread
 from octopus.core import app, initialise
 from service import reports
 from service import models
+from service.lib.cleanup_repository_logs import cleanup_repository_logs
 
 if app.config.get('DEEPGREEN_EZB_ROUTING', False):
     from service import routing_deepgreen as routing
@@ -488,6 +489,10 @@ def delete_old_routed():
 
 if app.config.get('SCHEDULE_DELETE_OLD_ROUTED', False):
     schedule.every().day.at("03:00").do(delete_old_routed)
+
+
+if app.config.get('SCHEDULE_DELETE_OLD_SWORD_LOGS', False):
+    schedule.every().day.at("04:00").do(cleanup_repository_logs)
 
 
 def cheep():


### PR DESCRIPTION
fixes https://github.com/CottageLabs/deepgreen/issues/97

need to add the following to `local.cfg`
```
# Scheduler config to remove old sword logs
SCHEDULE_DELETE_OLD_SWORD_LOGS = True
SCHEDULE_KEEP_SWORD_LOGS_MONTHS = 3
```