### PR TITLE
xslt syntax error fix

### DIFF
--- a/service/models/xslt.py
+++ b/service/models/xslt.py
@@ -1000,6 +1000,7 @@ class XSLT(object):
             </xsl:when>
             <xsl:otherwise>
                 <xsl:text>-12</xsl:text>
+            </xsl:otherwise>
         </xsl:choose>
         <xsl:if test="day">
             <xsl:text>-</xsl:text>


### PR DESCRIPTION
fixed a pesky syntax error in `jats2metsmods`