### PR TITLE
Merge Hotfix/metsmods

### DIFF
--- a/service/models/xslt.py
+++ b/service/models/xslt.py
@@ -186,11 +186,11 @@ class XSLT(object):
               <xsl:value-of select="normalize-space()"/>
             </title>
           </xsl:for-each>
-          <xsl:if test="//article-meta/title-group/subtitle">
+          <xsl:if test="//article-meta/title-group/subtitle[not(@content-type='running-title') and not(@content-type='running-author')]">
             <title>
               <xsl:attribute name="language"><xsl:value-of select="$langOut"/></xsl:attribute>
               <xsl:attribute name="type"><xsl:text>sub</xsl:text></xsl:attribute>
-              <xsl:value-of select="normalize-space(//article-meta/title-group/subtitle)"/>
+              <xsl:value-of select="normalize-space(//article-meta/title-group/subtitle[not(@content-type='running-title') and not(@content-type='running-author')])"/>
             </title>
           </xsl:if>
           <xsl:for-each select="//article-meta/title-group/trans-title-group/trans-subtitle">
@@ -665,7 +665,7 @@ class XSLT(object):
                         <xsl:value-of select="normalize-space()"/>
                     </mods:title>
                 </xsl:for-each>
-                <xsl:for-each select="//article-meta/title-group/subtitle">
+                <xsl:for-each select="//article-meta/title-group/subtitle[not(@content-type='running-title') and not(@content-type='running-author')]">
                     <mods:subTitle>
                         <xsl:call-template name="insert-lang-attribute"/>
                         <xsl:value-of select="normalize-space()"/>

--- a/service/models/xslt.py
+++ b/service/models/xslt.py
@@ -790,11 +790,11 @@ class XSLT(object):
                           </xsl:if>
                           <mods:role>
                             <mods:roleTerm type="text">
-                                <xsl:choose>
-                                    <xsl:when test="@corresp='yes' or .//xref[@ref-type='corresp']">corresponding author</xsl:when>
-                                    <xsl:otherwise><xsl:value-of select="@contrib-type"/></xsl:otherwise>
-                                </xsl:choose>
+                                <xsl:value-of select="@contrib-type"/>
                             </mods:roleTerm>
+                            <xsl:if test=test="@corresp='yes' or .//xref[@ref-type='corresp']">
+                              <mods:roleTerm type="text">corresponding author </mods:roleTerm>
+                            </xsl:if>
                           </mods:role>
                           <!-- Identifier: So far, support of ORCIDs (and email adresses?) only -->
                           <xsl:for-each select="./contrib-id">

--- a/service/models/xslt.py
+++ b/service/models/xslt.py
@@ -792,8 +792,8 @@ class XSLT(object):
                             <mods:roleTerm type="text">
                                 <xsl:value-of select="@contrib-type"/>
                             </mods:roleTerm>
-                            <xsl:if test=test="@corresp='yes' or .//xref[@ref-type='corresp']">
-                              <mods:roleTerm type="text">corresponding author </mods:roleTerm>
+                            <xsl:if test="@corresp='yes' or .//xref[@ref-type='corresp']">
+                              <mods:roleTerm type="text">corresponding author</mods:roleTerm>
                             </xsl:if>
                           </mods:role>
                           <!-- Identifier: So far, support of ORCIDs (and email adresses?) only -->


### PR DESCRIPTION
This fixes the corresponding author mapping in METS-MODS packages. Improves on [PR 106](https://github.com/OA-DeepGreen/jper/pull/106).

Instead of overwriting the "role" value from the JATS if the author is a corresponding author, it is now added as a second mods:roleterm element. 

The overwriting solution caused problems for the repositories whose crosswalks filtered strictly which contributors are mapped to the author field. The corresponding authors were then excluded from import the same way an issue editor is.

Previously:
```xml
<mods:name type="personal">
     <mods:namePart type="family">-</mods:namePart>
     <mods:namePart type="given">-</mods:namePart>
     <mods:role>
         <mods:roleTerm type="text">corresponding author</mods:roleTerm>
     </mods:role>
     <mods:affiliation> [...] </mods:affiliation>
</mods:name>
```

Now:
```xml
<mods:name type="personal">
     <mods:namePart type="family">-</mods:namePart>
     <mods:namePart type="given">-</mods:namePart>
     <mods:role>
         <mods:roleTerm type="text">author</mods:roleTerm>
         <mods:roleTerm type="text">corresponding author</mods:roleTerm>
     </mods:role>
     <mods:affiliation> [...] </mods:affiliation>
</mods:name>
```


It further accommodates a bug we were recently alerted to:  Springer sometimes inserts page layout headers as `<subtitle>` elements, this change excludes them from being mapped to the mods and opus4 subtitle fields.