### PR TITLE
Fixes to get deletion of data on demand working

### DIFF
--- a/airflow/dags/jper_scheduler/delete_data_ondemand.py
+++ b/airflow/dags/jper_scheduler/delete_data_ondemand.py
@@ -49,18 +49,17 @@ def delete_data_ondemand():
         if b == None or len(b) == 0:
             app.logger.error("Open search returned null record- exiting")
             return []
-        num_records = b['hits']['total']['value']
+        num_records = b.get('hits', {}).get('total', {}).get('value', 0)
         if num_records == 0:
             app.logger.info("No records returned from open search matching query - exiting")
             return []
 
         page = 1
         page_size = 10000
-        total = b.get('hits', {}).get('total', {}).get('value', 0)
-        num_pages = int(math.ceil(total / page_size))
+        num_pages = int(math.ceil(num_records / page_size))
         info_to_run = []
         for page in range(1, 1+num_pages):
-            records = RoutingHistory.pull_records(since=brom, upto=upto, page=page, page_size=page_size, publisher_id=publisher_id,)
+            records = RoutingHistory.pull_records(since=brom, upto=upto, page=page, page_size=page_size, publisher_id=publisher_id)
             if records == None or len(records) == 0:
                 app.logger.error(f"Open search returned null record for page {page} - finishing")
                 continue

--- a/service/dao.py
+++ b/service/dao.py
@@ -963,7 +963,7 @@ class RoutingHistoryDAO(dao.ESDAO):
     def pull_records(cls, since=None, upto=None, page=1, page_size=1000, publisher_id=None,
                      publisher_email=None, doi=None, notification_id=None, status=None, workflow_action=None):
 
-        if notification_id != '':
+        if notification_id and notification_id != '':
             query = {
                 "query": {
                     "bool": {
@@ -971,7 +971,7 @@ class RoutingHistoryDAO(dao.ESDAO):
                     }
                 }
             }
-        elif doi != '':
+        elif doi and doi != '':
             query = {
                 "query": {
                     "bool": {
@@ -991,40 +991,41 @@ class RoutingHistoryDAO(dao.ESDAO):
                 "size": page_size
             }
 
-            if since != '' and upto != '':
+            if since and since != '' and upto and upto != '':
                 if not 'filter' in query['query']['bool']:
                     query['query']['bool']["filter"] = []
                 query['query']['bool']["filter"].append({'range': {'created_date': {"gte": since, "lte": upto} }})
-            elif since != '':
+            elif since and since != '':
                 if not 'filter' in query['query']['bool']:
                     query['query']['bool']["filter"] = []
                 query['query']['bool']["filter"].append({'range': {'created_date': {"gte": since}}})
-            elif upto != '':
+            elif upto and upto != '':
                 if not 'filter' in query['query']['bool']:
                     query['query']['bool']["filter"] = []
                 query['query']['bool']["filter"].append({'range': {'created_date': {"lte": upto}}})
 
-            if publisher_id != '':
+            if publisher_id and publisher_id != '':
                 query['query']['bool']["must"].append({"match": {"publisher_id.exact": publisher_id}})
 
-            if publisher_email != '':
+            if publisher_email and publisher_email != '':
                 query['query']['bool']["must"].append({"match": {"publisher_email.exact": publisher_email}})
 
-            if workflow_action != '':
+            if workflow_action and workflow_action != '':
                 query['query']['bool']["must"].append({"match": {"workflow_states.action.exact": workflow_action}})
 
-            if status.lower() == "error":
-                query['query']['bool']["must"].append({"match": {"workflow_states.status.exact": "failure"}})
-            elif status.lower() == "routed":
-                query['query']['bool']['must_not'] = [{"match": {"workflow_states.status.exact": "failure"}}]
-                if not 'filter' in query['query']['bool']:
-                    query['query']['bool']["filter"] = {}
-                query['query']['bool']["filter"].append({'range': {'notification_states.number_matched_repositories': {"gte": 1}}})
-            elif status.lower() == "failed":
-                query['query']['bool']['must_not'] = [{"match": {"workflow_states.status.exact": "failure"}}]
-                if not 'filter' in query['query']['bool']:
-                    query['query']['bool']["filter"] = {}
-                query['query']['bool']["filter"].append({'range': {'notification_states.number_matched_repositories': {"lt": 1}}})
+            if status and status:
+                if status.lower() == "error":
+                    query['query']['bool']["must"].append({"match": {"workflow_states.status.exact": "failure"}})
+                elif status.lower() == "routed":
+                    query['query']['bool']['must_not'] = [{"match": {"workflow_states.status.exact": "failure"}}]
+                    if not 'filter' in query['query']['bool']:
+                        query['query']['bool']["filter"] = {}
+                    query['query']['bool']["filter"].append({'range': {'notification_states.number_matched_repositories': {"gte": 1}}})
+                elif status.lower() == "failed":
+                    query['query']['bool']['must_not'] = [{"match": {"workflow_states.status.exact": "failure"}}]
+                    if not 'filter' in query['query']['bool']:
+                        query['query']['bool']["filter"] = {}
+                    query['query']['bool']["filter"].append({'range': {'notification_states.number_matched_repositories': {"lt": 1}}})
         print(query)
         ans = cls.query(q=query)
         return ans

--- a/service/views/delete_notifications.py
+++ b/service/views/delete_notifications.py
@@ -30,7 +30,7 @@ def index():
         upto = validate_date(default_upto, param='upto')
         publisher_ids = {
             'label': 'Publisher ID',
-            'values': models.RoutingHistory.get_all_publishers(),
+            'values': models.RoutingHistory.get_all_publisher_ids(),
             'selected': request.args.get('publisher_id', ''),
             'term': 'publisher_id.exact'
         }
@@ -79,9 +79,7 @@ def index():
 
     # Call airflow dag here to delete with these params
     jper_url = app.config.get("BASE_URL", "http://localhost")
-    airflow_host = airflow_conf.get("webserver", "WEB_SERVER_HOST")
-    airflow_host = "localhost"
-    airflow_url = f"http://{airflow_host}/airflow"
+    airflow_url = app.config.get("JPER_AIRFLOW_CONNECT_URL", "http://localhost:8080/airflow")
     airflow_rest_url = f"{airflow_url}/api/v1/dags/"
     deletion_dag = "Delete_Data_OnDemand"
     user = app.config.get("AIR_USER_USER", 'None')
@@ -110,7 +108,7 @@ def index():
         flash(f"Successfully triggered Airflow DAG to delete notifications between {brom} and {upto}.")
     else:
         flash(f"Failed to trigger Airflow DAG. Status code: {r.status_code}, response: {r.text}")
-        return render_template('delete_notifications/index.html', publisher_id=publisher_id,
+        return render_template('delete_notifications/deletion_sent.html', publisher_id=publisher_id,
                            brom=brom, upto=upto, status_values=status_values)
     print(f"Airflow deletion request: {r.request.body}")
     print(f"Airflow deletion url: {r.url}")


### PR DESCRIPTION
This PR has 3 fixes

1. Fix `service/dao.py` to cleanly handle `None` value for the arguments. This was otherwise giving the wrong ES query.
2. Clean up the jper connection to airflow in `service/views/delete_notifications.py`. This should now work both in the test / dev instances (where nginx is used for routing the web queries) and in the production instance
3. Update `airflow/dags/jper_scheduler/delete_data_ondemand.py` to handle the response dictionary from ES correctly. Basically use `get` of the key with a default value, instead of using just the key which may or may not exist depending on the query status.