### PR TITLE
Map issue number only when element is not empty.

### DIFF
--- a/service/models/xslt.py
+++ b/service/models/xslt.py
@@ -125,7 +125,7 @@ class XSLT(object):
               <xsl:value-of select="//article-meta/volume"/>
             </xsl:attribute>
           </xsl:if>
-          <xsl:if test="//article-meta/issue">
+          <xsl:if test="//article-meta/issue/text()">
             <xsl:attribute name="issue">
               <xsl:value-of select="//article-meta/issue"/>
             </xsl:attribute>
@@ -710,7 +710,7 @@ class XSLT(object):
                             <mods:number><xsl:value-of select="//article-meta/volume"/></mods:number>
                         </mods:detail>
                     </xsl:if>
-                    <xsl:if test="//article-meta/issue">
+                    <xsl:if test="//article-meta/issue/text()">
                         <mods:detail type="issue">
                             <mods:number><xsl:value-of select="//article-meta/issue"/></mods:number>
                         </mods:detail>


### PR DESCRIPTION
I noticed that JATS from CUP puts the article number into issue@seq, without any text content: `<issue seq="17"/>`. (elocation-id is given as e17, and I checked, the articles do not have an issue number)

The current xslt created empty tags and attributes in the mapped opus4 and metsmods XML files. This change only inserts the issue element/tag if `<issue>` has text content.