### PR TITLE
First round of multiple updates for user friendliness and convenience

### DIFF
--- a/airflow/dags/jper_scheduler/delete_data_ondemand.py
+++ b/airflow/dags/jper_scheduler/delete_data_ondemand.py
@@ -1,27 +1,32 @@
 # Python stuff
-from datetime import datetime
+import os
 import math
-import re
-from dateutil.relativedelta import relativedelta
-from octopus.core import app
-from service.models.routing_history import RoutingHistory
-# Airflow stuff
-from airflow.exceptions import AirflowException, AirflowFailException, AirflowTaskTerminated
-from airflow.decorators import dag, task, task_group
-from airflow.operators.python import get_current_context
-from airflow.utils.session import provide_session
-from airflow.configuration import conf
-# My code
-from jper_scheduler.routing_deletions import RoutingDeletion
-from jper_scheduler.notification_helpers import notifications_before, iter_notifications_before
-from jper_scheduler.utils import set_task_name, get_log_url, get_notifications_for, create_routing_history_record
-from jper_scheduler.utils import utils_log_routing_history
-from service import models
+import json
+import fcntl
+from pathlib import Path
+from datetime import datetime
 
 # Create a connection - ES stuff
+from airflow.dags.one_time_runs.create_routing_history import write_notifications
 import esprit
-host = app.config.get("ELASTIC_SEARCH_HOST", 'localhost') # includes port
-index = 'jper-routed*,jper-failed' # Comma-separated list of ES indices to query for notifications to reprocess
+from airflow.decorators import dag, task, task_group
+
+# Airflow stuff
+from airflow.exceptions import AirflowException, AirflowFailException, AirflowTaskTerminated
+from airflow.operators.python import get_current_context
+from airflow.utils.session import provide_session
+from dateutil.relativedelta import relativedelta
+
+# My code
+from jper_scheduler.routing_deletions import RoutingDeletion
+from jper_scheduler.utils import create_routing_history_record, get_log_url, get_notifications_for, set_task_name
+from octopus.core import app
+
+from service import models
+from service.models.routing_history import RoutingHistory
+
+host = app.config.get("ELASTIC_SEARCH_HOST", "localhost")  # includes port
+index = "jper-routed*,jper-failed"  # Comma-separated list of ES indices to query for notifications to reprocess
 # index = 'jper-routed*'
 # index = 'jper-failed'
 max_query = app.config.get("AIRFLOW_REPROCESS_MAX_QUERY", 5000) # Max number of notifications to fetch in one query from ES - adjust as needed based on performance and memory constraints.
@@ -29,115 +34,290 @@ port = host.split(':')[-1]
 host_name = host.split(port)[0][:-1]
 conn = esprit.raw.Connection(host_name, index, port=port)
 
-@dag(dag_id="Delete_Data_OnDemand", max_active_runs=1,
-     schedule=None, schedule_interval=app.config.get("AIRMAINT_DELETE_DEMAND_SCHED", 'None'),
-     start_date=datetime(2025, 10, 22),
-     description="Delete data according to on-demand request",
-     catchup=False,
-     tags=["teamCottageLabs", "jper_cleanup"])
-def delete_data_ondemand():
-    # Clean data on demand - called using REST api or Airflow UI
-    @task(task_id="list_old_routing_data_on_demand", retries=0, max_active_tis_per_dag=1)
-    def list_old_routing_data_on_demand():
-        context = get_current_context()
-        app.logger.info("Starting on-demand old routing data cleanup")
-        if len(context['params']) == 0:
-            app.logger.info("No parameters given for on-demand cleanup - exiting")
-            return []
+del_log_path = app.config.get("AIRFLOW_DELETION_LOGS_PATH", '/logs/data_deletion_logs')
+notifications_to_process = app.config.get("AIRFLOW_DELETION_NOTIFICATION_BATCH_SIZE", 3000) # Notifications to process at a given time.
 
-        a = RoutingHistory()
-        info_to_run = []
-        status_values = []
-        notification_id = context['params'].get('notification_id', None)
-        rerouting = context['params'].get('rerouting', None)
-        deletion_reason = context['params'].get('deletion_reason', None)
-        if notification_id:
-            app.logger.info(f"Notification ID provided: {notification_id} - searching for routing history records linked to this notification")
-            app.logger.info(f"Rerouting value provided: {rerouting} - setting status values accordingly")
-            app.logger.info(f"Deletion reason provided: {deletion_reason}")
-            info_to_run.append((notification_id, status_values, rerouting, deletion_reason))
-            return info_to_run
-        
-        publisher_id = context['params'].get('publisher_id', None)
-        status_values = context['params'].get('status_values', [])
-        upto = context['params'].get('upto', None)
-        brom = context['params'].get('from', None)
+#####
+def write_notifications_to_delete(params, del_file):
+    if os.path.exists(del_file):
+        # File exists! Should not happen?
+        app.logger.warning(f"File {del_file} already exists - should not happen...")
+        del_file = del_file.with_name(f"{del_file.name}.bak")
+        if os.path.exists(del_file):
+            raise FileExistsError(f"Original and Backup files {del_file} already exists - should not happen...")
+    publisher_id = params.get("publisher_id", None)
+    publisher_email = params.get("publisher_email", None)
+    status_values = params.get("status_values", [])
+    upto = params.get("upto", None)
+    brom = params.get("from", None)
+    rerouting = params.get("rerouting", None)
+    deletion_reason = params.get("deletion_reason", None)
 
-        app.logger.info(f"Parameters to search for routing history records:")
-        app.logger.info(f"publisher_id: {publisher_id}")
-        app.logger.info(f"status_values: {status_values}")
-        app.logger.info(f"from: {brom}")
-        app.logger.info(f"upto: {upto}")
+    app.logger.info(f"Parameters to search for routing history records:")
+    app.logger.info(f"publisher_id: {publisher_id}")
+    app.logger.info(f"publisher_email: {publisher_email}")
+    app.logger.info(f"status_values: {status_values}")
+    app.logger.info(f"from: {brom}")
+    app.logger.info(f"upto: {upto}")
+    app.logger.info(f"rerouting: {rerouting}")
+    app.logger.info(f"deletion_reason: {deletion_reason}")
 
-        b = get_notifications_for(conn=conn, since=brom, upto=upto, page=1, page_size=1000, publisher_id=publisher_id)
-        if b == None or len(b) == 0:
-            app.logger.error("Open search returned null record- exiting")
-            return []
-        num_records = b.get('hits', {}).get('total', {}).get('value', 0)
-        if num_records == 0:
-            app.logger.info("No records returned from open search matching query - exiting")
-            return []
+    page_size = 1000
+    records = get_notifications_for(
+        conn=conn,
+        since=brom,
+        upto=upto,
+        page=1,
+        page_size=page_size,
+        publisher_id=publisher_id,
+    )
+    scroll_id = records["_scroll_id"]
+    if records == None or len(records) == 0:
+        app.logger.error("Open search returned null record- exiting")
+        return []
+    num_records = records.get("hits", {}).get("total", {}).get("value", 0)
+    if num_records == 0:
+        app.logger.info("No records returned from open search matching query - exiting")
+        return []
 
-        page = 1
-        page_size = 10000
+    for hit in records["hits"]["hits"]:
+        notification_id = hit["_id"]
+        info_to_run.append((notification_id, status_values, rerouting, deletion_reason, publisher_id, del_file))
+
+    if num_records > page_size:
+        page = 2
         num_pages = int(math.ceil(num_records / page_size))
         info_to_run = []
-        for page in range(1, 1+num_pages):
-            records = get_notifications_for(conn=conn, since=brom, upto=upto, page=page, page_size=page_size, publisher_id=publisher_id)
+        for page in range(2, 1 + num_pages):
+            records = get_notifications_for(
+                conn=conn,
+                since=brom,
+                upto=upto,
+                scroll_id=scroll_id,
+                page=page,
+                page_size=page_size,
+                publisher_id=publisher_id,
+            )
             if records == None or len(records) == 0:
-                app.logger.error(f"Open search returned null record for page {page} - finishing")
+                app.logger.info(
+                    f"Open search returned null record for page {page} - finishing"
+                )
                 break
-            for hit in records['hits']['hits']:
-                notification_id = hit['_source']['id']
-                info_to_run.append((notification_id, status_values, rerouting, deletion_reason))
+            for hit in records["hits"]["hits"]:
+                notification_id = hit["_id"]
+                info_to_run.append((notification_id, status_values, rerouting, deletion_reason, publisher_id, del_file))
+            # if page > 2:
+            #     break
+    app.logger.info(f"Total number of notifications to process: {len(info_to_run)}")
+
+    info_to_write = {}
+    info_to_write["publisher_id"] = publisher_id
+    info_to_write["publisher_email"] = publisher_email
+    info_to_write["status_values"] = status_values
+    info_to_write["from"] = brom
+    info_to_write["upto"] = upto
+    info_to_write["rerouting"] = rerouting
+    info_to_write["deletion_reason"] = deletion_reason
+    info_to_write["total_notifications"] = len(info_to_run)
+    info_to_write["remaining_notifications"] = len(info_to_run)
+    info_to_write["notifications"] = info_to_run
+
+    if not os.path.exists(del_file.parent):
+        os.makedirs(del_file.parent)
+    with open(del_file, 'a') as f:
+        f.write(json.dumps(info_to_write) + '\n')
+
+#####
+
+def read_notifications_to_delete():
+    info_to_run = []
+    path = Path(outputPath).rglob('TODO/*.json')
+
+    kount = 0
+    done = False
+    for file in path:
+        if not os.path.exists(file):
+            app.logger.info(f"File not found: {file}. Should not have happened, skipping ...")
+            continue
+        with open(file, 'r') as f:
+            data = json.loads(f)
+        # info_to_run.extend(data["notifications"])
+        # info_to_run.append((notification_id, status_values, rerouting, deletion_reason, None, del_file))
+        for notification in data["notifications"]:
+            info_to_run.append(notification, data["status_values"], data["rerouting"], data["deletion_reason"], data["publisher_id"], file)
+            kount += 1
+            if kount >= notifications_to_process:
+                done = True
+                break
+        if done:
+            break
+    app.logger.info(f"Found {kount} notifications to delete")
+    return info_to_run
+
+#####
+
+def update_deletion_log_files(del_log_file, airflow_log_url, notification_id, status):
+    if not del_log_file:
+        app.logger.info(f"No deletion log file specified : {del_log_file}. Returning.")
+        return
+    if "TODO" not in del_log_file.parts:
+        app.logger.info(f"Deletion log file {del_log_file} is not a TODO file. Returning.")
+        return
+
+    words = []
+    for word in del_log_file.parts:
+        if word == "TODO":
+            if status == "success":
+                word = "DONE"
+            else:
+                word = "FAILED"
+        words.append(word)
+    final_file = Path("/".join(words)[1:])
+    if not os.path.exists(final_file.parent):
+        os.makedirs(final_file.parent)
+
+    # Read the input log file, update it, and write it back
+    tmp_list = []
+    with open(del_log_file, 'r') as f:
+        fcntl.flock(f, fcntl.LOCK_EX)
+        data = json.loads(f.read())
+
+        for note_list in data["notifications"]:
+            if notification_id in note_list:
+                tmp_list = note_list
+        data["notifications"].remove(tmp_list)
+        data["remaining_notifications"] = len(data["notifications"])
+
+        f.seek(0)
+        f.truncate(0)
+        f.write(json.dumps(data))
+        fcntl.flock(f, fcntl.LOCK_UN)
+
+    # Read the updated log file and append the new notification that has just been deleted
+    if not tmp_list:
+        app.logger.info(f"No notification found with id {notification_id}?")
+        raise ValueError(f"No notification found with id {notification_id} while updating DONE log file")
+    tmp_list.append(airflow_log_url)
+    with open(final_file, 'w') as f:
+        fcntl.flock(f, fcntl.LOCK_EX)
+        data = json.loads(f.read())
+        data["notifications"].append(tmp_list)
+        data["completed_notifications"] = len(data["notifications"])
+
+        f.seek(0)
+        f.truncate(0)  # Clear the file before writing for safety
+        f.write(json.dumps(data))
+        fcntl.flock(f, fcntl.LOCK_UN)
+
+#####
+
+@dag(
+    dag_id="Delete_Data_OnDemand",
+    max_active_runs=1,
+    schedule=None,
+    schedule_interval=app.config.get("AIRMAINT_DELETE_DEMAND_SCHED", "None"),
+    start_date=datetime(2025, 10, 22),
+    description="Delete data according to on-demand request",
+    catchup=False,
+    tags=["teamCottageLabs", "jper_cleanup"],
+)
+def delete_data_ondemand():
+    # Clean data on demand - called using REST api or Airflow UI
+    @task(
+        task_id="list_old_routing_data_on_demand",
+        retries=0,
+        max_active_tis_per_dag=1,
+    )
+    def list_old_routing_data_on_demand():
+        context = get_current_context()
+
+        del_file = Path(del_log_path) / "TODO" / f"deletion_log_{datetime.now().strftime('%Y%m%d_%H%M%S')}.json"
+        info_to_run = []
+        status_values = []
+
+        if len(context["params"]) > 0:
+            app.logger.info("Starting on-demand notification cleanup")
+            rerouting = context["params"].get("rerouting", None)
+            deletion_reason = context["params"].get("deletion_reason", None)
+
+            notification_id = context["params"].get("notification_id", None)
+            if notification_id:
+                # Deletion of single notification. Do it immediately and return / stop the run.
+                app.logger.info(f"Notification ID provided: {notification_id} - searching for routing history records linked to this notification")
+                app.logger.info(f"Rerouting value provided: {rerouting} - setting status values accordingly")
+                app.logger.info(f"Deletion reason provided: {deletion_reason}")
+                write_notifications_to_delete(context["params"], del_file=del_file)
+                info_to_run.append((notification_id, status_values, rerouting, deletion_reason, None, del_file))
+                return info_to_run # Run it immediately
+            else:
+                # (Likely) multiple notifications to delete. Do it in batches.
+                write_notifications_to_delete(context["params"], del_file=del_file)
+
+        # Process the notifications from all the available deletion requests
+        info_to_run = read_notifications_to_delete()
         return info_to_run[:3]
 
-    @task(task_id="retrieve_create_notification", retries=0, max_active_tis_per_dag=1)
-    def retrieve_create_notification(routing_tuple):
+    @task(task_id="get_create_RH_for_note", retries=0, max_active_tis_per_dag=1)
+    def get_create_routing_history(routing_tuple):
         # Separate task for retrieving notifications, as it could need a creation of routing history. This is
         # best / most safely done in a separate task.
         # If the deletion is done in the same task as the creation, a newly created routing history appears empty.
         context = get_current_context()
         log_url = get_log_url(context)
 
-        notification_id = routing_tuple[0]
         b = RoutingHistory()
+        notification_id = routing_tuple[0]
         status_values = routing_tuple[1]
         rerouting = routing_tuple[2]
         deletion_reason = routing_tuple[3]
+        publisher_id = routing_tuple[4]
+        del_log_file = routing_tuple[5]
+
         routing_id = ""
-        publisher_id = ""
         app.logger.info(f"Notification ID provided: {notification_id} - searching for routing history records linked to this notification")
         c = b.pull_records(notification_id=notification_id)
-        num_records = c.get('hits', {}).get('total', {}).get('value', 0)
-        if num_records >= 1: # Found the notification with a routing ID
-            hit = c['hits']['hits'][0]
-            routing_id = hit['_source']['id']
+        num_records = c.get("hits", {}).get("total", {}).get("value", 0)
+        if num_records >= 1:  # Found the notification with a routing ID
+            hit = c["hits"]["hits"][0]
+            routing_id = hit["_source"]["id"]
             try:
-                publisher_id = hit['_source']['publisher_id']
+                temp_id = hit["_source"]["publisher_id"]
             except KeyError:
-                # Improperly created routing history. Create a new one.
+                # Improperly created routing history (should not happen?). Create a new one.
                 note = get_notifications_for(conn=conn, notification_id=notification_id)
-                note_index = note['hits']['hits'][0]['_index']
+                note_index = note["hits"]["hits"][0]["_index"]
                 app.logger.info(f"Improperly created routing history ID {routing_id}. Creating a new one for this notification.")
                 rh_tuple = create_routing_history_record(note_index, notification_id, log_url=log_url)
                 routing_id = rh_tuple[0]
-                publisher_id = rh_tuple[1]
-        else: # Is it an old notification without a routing ID?
-            app.logger.info(f"No routing history record found linked to notification ID {notification_id} - checking if it's an old notification without routing ID")
+                temp_id = rh_tuple[1]
+            if not publisher_id:
+                publisher_id = temp_id
+        else:  # Is it an old notification without a routing ID?
+            app.logger.info(
+                f"No routing history record found linked to notification ID {notification_id} - checking if it's an old notification without routing ID"
+            )
             note = get_notifications_for(conn=conn, notification_id=notification_id)
-            if not note or len(note.get('hits', {}).get('hits', [])) != 1:
-                app.logger.info(f"No notification found in ES with ID {notification_id} - maybe deleted already? Exiting")
-                return 'success'
+            if not note or len(note.get("hits", {}).get("hits", [])) != 1:
+                app.logger.info(f"No notification found in ES with ID {notification_id}.")
+                return "success"
             # Found a notification without a routing history. Create a routing history record for it, so it can be deleted like the others
             app.logger.info(f"Found notification with ID {notification_id} but no routing history record - creating a routing history record for it to enable deletion")
-            note_index = note['hits']['hits'][0]['_index']
+            note_index = note["hits"]["hits"][0]["_index"]
             rh_tuple = create_routing_history_record(note_index, notification_id, log_url=log_url)
             routing_id = rh_tuple[0]
-            publisher_id = rh_tuple[1]
+            if not publisher_id:
+                publisher_id = rh_tuple[1]
             app.logger.info(f"Publisher : {publisher_id}, RH : {routing_id}, Note : {notification_id}")
 
-        return(routing_id, publisher_id, notification_id, status_values, rerouting, deletion_reason)
+        return (
+            routing_id,
+            publisher_id,
+            notification_id,
+            status_values,
+            rerouting,
+            deletion_reason,
+            del_log_file,
+        )
 
     @task(task_id="delete_old_notification_id", retries=0, max_active_tis_per_dag=1)
     def delete_notification(routing_tuple):
@@ -150,20 +330,31 @@ def delete_data_ondemand():
         status_values = routing_tuple[3]
         rerouting = routing_tuple[4]
         deletion_reason = routing_tuple[5]
+        del_log_file = routing_tuple[6]
 
-        ti = context['ti']  # TaskInstance
+        ti = context["ti"]  # TaskInstance
         context["map_index_template"] = set_task_name(ti.map_index, routing_id)
         a = RoutingDeletion(publisher_id=publisher_id, routing_id=routing_id)
         a.airflow_log_location = log_url
-        status = a.clean_all(notification_id=notification_id, status_values=status_values, rerouting=rerouting, deletion_reason=deletion_reason)
-        app.logger.info(f"Routing history deletion status: {status['status']}, Message: {status['message']}")
-        if status['status'] == "error":
-            raise AirflowFailException(f"Error in deleting routing history for notification ID {notification_id}. Message: {status['message']}")
-        return status['status']
+        status = a.clean_all(
+            notification_id=notification_id,
+            status_values=status_values,
+            rerouting=rerouting,
+            deletion_reason=deletion_reason,
+        )
+        app.logger.info(
+            f"Routing history deletion status: {status['status']}, Message: {status['message']}"
+        )
+        if status["status"] == "error":
+            raise AirflowFailException(
+                f"Error in deleting routing history for notification ID {notification_id}. Message: {status['message']}"
+            )
+        update_deletion_log_files(del_log_file, log_url, notification_id, status['status'])
+        return status["status"]
 
-    @task_group(group_id='ProcessAndDeleteNotification')
+    @task_group(group_id="ProcessAndDeleteNotification")
     def process_one_notification(routing_tuple, **context):
-        local_tuple = retrieve_create_notification(routing_tuple=routing_tuple)
+        local_tuple = get_create_routing_history(routing_tuple=routing_tuple)
         delete_notification(routing_tuple=local_tuple)
 
     routing_tuple = list_old_routing_data_on_demand()

--- a/airflow/dags/jper_scheduler/routing_deletions.py
+++ b/airflow/dags/jper_scheduler/routing_deletions.py
@@ -1,37 +1,43 @@
-import os, shutil
+import os
+import shutil
 from datetime import datetime, timezone
-from service import models
+from pathlib import Path
+
+from jper_scheduler.publisher_transfer import PublisherFiles
 from octopus.core import app
 from octopus.modules.store import store
-from jper_scheduler.publisher_transfer import PublisherFiles
+
+from service import models
 
 dryRun = app.config.get("AIRFLOW_DELETION_DRY_RUN", True)
+
 
 # Check if notification is okay to delete based on status values provided for on-demand deletion
 def is_notification_okay(note, status_values):
     # If status values are provided, only delete notifications with those status values
-    if note['status'] == 'failure' and 'failure' in status_values:
+    if note["status"] == "failure" and "failure" in status_values:
         return True
-    if note['status'] == 'success':
-        num_repo = note.get('number_matched_repositories', None)
+    if note["status"] == "success":
+        num_repo = note.get("number_matched_repositories", None)
         if not num_repo:
             # Needed in case of failure in processftp_dir where the notification is created but the number of matched repositories
             # is not added to the notification states in routing history. In that case, we will pull the notification object to
             # get the number of matched repositories.
-            obj = models.RoutedNotification.pull(note['notification_id'])
+            obj = models.RoutedNotification.pull(note["notification_id"])
             if not obj:
-                obj = models.FailedNotification.pull(note['notification_id'])
+                obj = models.FailedNotification.pull(note["notification_id"])
             if obj and obj.repositories:
                 num_repo = len(obj.repositories)
         if not num_repo:
-            return False # If still failure, return False to avoid deleting notifications that we are not sure about
-        if 'success-routed' in status_values:
+            return False  # If still failure, return False to avoid deleting notifications that we are not sure about
+        if "success-routed" in status_values:
             if num_repo > 0:
                 return True
-        if 'success-no-matches' in status_values:
+        if "success-no-matches" in status_values:
             if num_repo == 0:
                 return True
     return False
+
 
 # This class inherits from PublisherFiles (publisher_transfer.py) and will only
 # perform deletions.
@@ -39,8 +45,10 @@ def is_notification_okay(note, status_values):
 class RoutingDeletion(PublisherFiles):
     def __init__(self, publisher_id=None, routing_id=None):
         if not publisher_id or not routing_id:
-            app.logger.debug(f"Invalid routing {routing_id} or publisher {publisher_id}")
-            return -1
+            app.logger.debug(
+                f"Invalid routing {routing_id} or publisher {publisher_id}"
+            )
+            return None
         super().__init__(publisher_id, routing_id=routing_id)
 
     def routing_history_status(self):
@@ -69,7 +77,9 @@ class RoutingDeletion(PublisherFiles):
             self.scp.rmdir(remote_dir)
             app.logger.info(f"Successfully removed {remote_dir}.")
         except Exception as e:
-            app.logger.info(f"Failed to remove directory {remote_dir}. Error : {str(e)}")
+            app.logger.info(
+                f"Failed to remove directory {remote_dir}. Error : {str(e)}"
+            )
             app.logger.info("Directory probably not empty.")
         return 0
 
@@ -87,95 +97,148 @@ class RoutingDeletion(PublisherFiles):
     def clean_store_file(self, file_name):
         sf = store.StoreFactory.get()
         store_id = file_name.split("/")[5]
-        store_files = sf.list_file_paths(store_id)
-        for s_file in store_files:
-            sf.delete(store_id, s_file)
+        file_path = Path(file_name)
+        return_code = sf.delete(store_id, file_path.name)
+        if return_code == 200:
+            app.logger.info(f"Successfully removed {file_name} from store")
+        else:
+            app.logger.error(f"Failed to remove {file_name} from store. Return code: {return_code}")
+        return return_code
 
     # Clean local files and directories, except the ones in "keep" locations of RoutingHistory
     def clean_local_file(self, file_name, file_location):
         # If I come here, the files / directory should be removed
-        if len(file_name) < 40 and file_name.count("/") < 3: # Minor sanity check
-            app.logger.warn(f"Wrongness: File name {file_name} fails basic sanity check. Skipping.")
+        if len(file_name) < 40 and file_name.count("/") < 3:  # Minor sanity check
+            app.logger.warn(
+                f"Wrongness: File name {file_name} fails basic sanity check. Skipping."
+            )
             return -1
         if os.path.isfile(file_name) or os.path.islink(file_name):
-            app.logger.debug(f'Deleting file {file_name} from {file_location}')
+            app.logger.debug(f"Deleting file {file_name} from {file_location}")
             os.remove(file_name)
         else:
-            app.logger.debug(f'Deleting directory {file_name} from {file_location}')
+            app.logger.debug(f"Deleting directory {file_name} from {file_location}")
             shutil.rmtree(file_name, ignore_errors=True)
         return 0
 
     def clean_wfs_final_files(self, notification_id=None, keep=None):
         # Here, assume there is only one notification in the routing history
+        cleanup_files = {}
         app.logger.debug(f"Cleaning final files for notification ID {notification_id} in routing history ID {self.routing_history.id}")
         for final_location in self.routing_history.final_file_locations:
             file_name = final_location["file_location"]
             file_location = final_location["location_type"]
-            if keep and isinstance(keep, list) and len(keep)>0 and file_location in keep:
+            if (
+                keep
+                and isinstance(keep, list)
+                and len(keep) > 0
+                and file_location in keep
+            ):
                 # retain files in the above locations. They are precious.
-                app.logger.debug(f'Retain file {file_name} from {file_location}')
+                cleanup_files["retained"] = cleanup_files.get("retained", []) + [file_name]
+                app.logger.debug(f"Retain file {file_name} from {file_location}")
                 continue
-            app.logger.debug(f"--- Looking at file {file_name} in location {file_location}")
+            app.logger.debug(
+                f"--- Looking at file {file_name} in location {file_location}"
+            )
             if file_location == "store":
                 if dryRun:
                     app.logger.info(f"DRY RUN: Would delete store file {file_name}")
                 else:
-                    self.clean_store_file(file_name)
-            elif 'dg_storage' in file_name:
+                    ret_code = self.clean_store_file(file_name)
+                    if ret_code == 200:
+                        cleanup_files["deleted"] = cleanup_files.get("deleted", []) + [file_name]
+                    else:
+                        cleanup_files["failed"] = cleanup_files.get("failed", []) + [file_name]
+            elif "dg_storage" in file_name:
                 if dryRun:
                     app.logger.info(f"DRY RUN: Would delete local file {file_name}")
                 else:
-                    self.clean_local_file(file_name, file_location)
-            elif 'xfer' in file_name:
+                    self.clean_local_file(file_name, file_location) # Always returns 0
+                    cleanup_files["deleted"] = cleanup_files.get("deleted", []) + [file_name]
+            elif "xfer" in file_name:
                 if dryRun:
                     app.logger.info(f"DRY RUN: Would delete sftp file {file_name}")
                 else:
-                    self.clean_sftp_file(file_name, file_location)
+                    ret_code = self.clean_sftp_file(file_name, file_location)
+                    if ret_code == 0:
+                        cleanup_files["deleted"] = cleanup_files.get("deleted", []) + [file_name]
+                    else:
+                        cleanup_files["failed"] = cleanup_files.get("failed", []) + [file_name]
             else:
-                app.logger.warn(f"Unknown location of file : {file_name}. Doing nothing")
-        return { 'status': "success", 'message': f"Cleaned up files for only notification {notification_id} in routing history ID {self.routing_history.id}" }
+                app.logger.warn(
+                    f"Unknown location of file : {file_name}. Doing nothing"
+                )
+        return {
+            "status": "success",
+            "message": f"Cleaned up files for only notification {notification_id} in routing history ID {self.routing_history.id}",
+            "cleanup_files": cleanup_files,
+        }
 
     def clean_all_files_for_notification(self, notification_id=None, keep=None):
         # Clean all files linked to a notification ID in the routing history.
-
+        cleanup_files = {}
         for wfs in self.routing_history.workflow_states:
-            if 'notification_id' in wfs.keys() and wfs['notification_id'] == notification_id:
+            if (
+                "notification_id" in wfs.keys()
+                and wfs["notification_id"] == notification_id
+            ):
                 file_name = wfs["file_location"]
                 action = wfs["action"]
                 message = wfs["message"]
                 if not file_name or file_name == "None":
-                    continue # For checkunrouted or update states
+                    continue  # For checkunrouted or update states
 
                 okay_to_delete = True
-                if keep and isinstance(keep, list) and len(keep)>0:
+                if keep and isinstance(keep, list) and len(keep) > 0:
                     for k in keep:
                         if k in action or k in message:
                             okay_to_delete = False
-                            app.logger.info(f"Retain file {file_name} linked to workflow state with action {action} and message {message}")
+                            app.logger.info(
+                                f"Retain file {file_name} linked to workflow state with action {action} and message {message}"
+                            )
                             break
 
                 if not okay_to_delete:
+                    cleanup_files["retained"] = cleanup_files.get("retained", []) + [file_name]
                     continue
 
-                if not file_name or len(file_name) < 20 or file_name.count("/") < 2: # Minor sanity check
+                if (
+                   not file_name or len(file_name) < 20 or file_name.count("/") < 2
+                ):  # Minor sanity check
                     app.logger.warn(f"Wrongness: File name {file_name} fails basic sanity check. Skipping.")
                     app.logger.info(f"Action : {action}")
                     app.logger.info(f"Message : {message}")
+                    cleanup_files["failed"] = cleanup_files.get("failed", []) + [file_name]
                     continue
 
                 if dryRun:
                     app.logger.info(f"DRY RUN: Would delete file {file_name} linked to workflow state with action {wfs['action']}")
                 else:
-                    if 'dg_storage' in file_name:
+                    if "dg_storage" in file_name:
                         self.clean_local_file(file_name, wfs.get("location_type", "unknown"))
-                    elif 'xfer' in file_name:
-                        self.clean_sftp_file(file_name, wfs.get("location_type", "unknown"))
-                    elif 'store' in file_name:
-                        self.clean_store_file(file_name)
+                        cleanup_files["deleted"] = cleanup_files.get("deleted", []) + [file_name]
+                    elif "xfer" in file_name:
+                        return_code = self.clean_sftp_file(file_name, wfs.get("location_type", "unknown"))
+                        if return_code == 0:
+                            cleanup_files["deleted"] = cleanup_files.get("deleted", []) + [file_name]
+                        else:
+                            cleanup_files["failed"] = cleanup_files.get("failed", []) + [file_name]
+                    elif "store" in file_name:
+                        return_code = self.clean_store_file(file_name)
+                        if return_code == 200:
+                            cleanup_files["deleted"] = cleanup_files.get("deleted", []) + [file_name]
+                        else:
+                            cleanup_files["failed"] = cleanup_files.get("failed", []) + [file_name]
                     else:
+                        cleanup_files["retained"] = cleanup_files.get("retained", []) + [file_name]
                         app.logger.warn(f"Unknown location of file : {file_name}. Doing nothing")
 
-        return { 'status': "success", 'message': f"Cleaned up files for notification {notification_id} in routing history ID {self.routing_history.id}" }
+        return {
+            "status": "success",
+            "message": f"Cleaned up files for notification {notification_id} in routing history ID {self.routing_history.id}",
+            "cleanup_files": cleanup_files,
+        }
 
     # Clean all notifications
     def delete_notification(self, notification_id):
@@ -206,14 +269,24 @@ class RoutingDeletion(PublisherFiles):
                         app.logger.error(f"Failed to delete failed notification {notification_id}. Error: {str(e)}")
                         del_status = "failure"
             else:
-                app.logger.warn(f"Notification {notification_id} not found in either RoutedNotification or FailedNotification. Already deleted?")
-                return { 'status': "uncertain", 'message': "Notification not found, presumably already deleted." }
+                app.logger.warn(f"Notification {notification_id} not found in either RoutedNotification or FailedNotification.")
+                return { 'status': "uncertain", 'message': "Notification not found." }
 
-        return { 'status': del_status, 'message': "Cleaned up notifications for routing id {self.routing_history.id}" }
+        return {
+            "status": del_status,
+            "message": "Cleaned up notifications for routing id {self.routing_history.id}",
+        }
 
     # Clean everything for this routing history
-    def clean_all(self, notification_id=None, status_values=None, rerouting=None, deletion_reason=None):
+    def clean_all(
+        self,
+        notification_id=None,
+        status_values=None,
+        rerouting=None,
+        deletion_reason=None,
+    ):
 
+        wfs_message = ""
         keep = []
         if rerouting:
             keep = ["sftp_server"]
@@ -223,14 +296,24 @@ class RoutingDeletion(PublisherFiles):
         if not dryRun:
             statusN = self.delete_notification(notification_id=notification_id)
             app.logger.info(f"Notification cleanup status: {statusN['status']}, Message: {statusN['message']}")
-            if statusN['status'] == "uncertain":
-                return{'status': "success", 'message': f"Notification {notification_id} already deleted. Skipping file cleanup."}
+            if statusN['status'] == "success":
+                mess = f"Notification {notification_id} deleted"
+            elif statusN['status'] == "uncertain":
+                mess = f"Notification {notification_id} not found"
+            else:
+                mess = f"Notification {notification_id} not deleted"
+            wfs_message = mess
 
-        # At this point, the notification is available for deletion. Proceed to do the file cleanup
+        app.logger.info(f"Looking to see if there are any files to clean up")
+
+        # At this point, we should have a decent routing history. Proceed to do the file cleanup
         n_active_notifications = 0
         if len(self.routing_history.notification_states) == 0:
             app.logger.info(f"Notification without routing history? We have an error upstream.")
-            return { 'status': "error", 'message': f"Notification {notification_id} has no routing history states. This should not happen." }
+            return {
+                "status": "error",
+                "message": f"Notification {notification_id} has no routing history states. This should not happen.",
+            }
         elif len(self.routing_history.notification_states) == 1:
             # If there is only one notification in the routing history, we can clean all final files linked to the routing history
             app.logger.info(f"Only one notification in routing history {self.routing_history.id}. Cleaning all final files linked to the routing history.")
@@ -241,34 +324,75 @@ class RoutingDeletion(PublisherFiles):
                     n_active_notifications += 1
             if n_active_notifications == 0:
                 # Will I ever come here? Just in case ...
-                app.logger.info(f"All notifications in routing history {self.routing_history.id} are deleted. Cleaning all final files linked to the routing history.")
+                app.logger.info(f"All notifications in routing history {self.routing_history.id} are deleted.")
+                app.logger.info("Cleaning all final files linked to the routing history.")
                 statusF = self.clean_wfs_final_files(notification_id=notification_id, keep=keep)
             elif n_active_notifications == 1:
-                app.logger.info(f"Last active notification in routing history {self.routing_history.id} out of {len(self.routing_history.notification_states)}.")
-                app.logger.info(f"First clean files for notification ID {notification_id} in routing history {self.routing_history.id}.")
+                app.logger.info(
+                    f"Last active notification in routing history {self.routing_history.id} out of {len(self.routing_history.notification_states)}."
+                )
+                app.logger.info(
+                    f"First clean files for notification ID {notification_id} in routing history {self.routing_history.id}."
+                )
                 # Ignore statusF for clean_all_files_for_notificationas it will be success always.
-                statusF = self.clean_all_files_for_notification(notification_id=notification_id, keep=keep)
-                app.logger.info(f"Now clean all final files linked to the routing history ID {self.routing_history.id}")
-                statusF = self.clean_wfs_final_files(notification_id=notification_id, keep=keep)
+                statusF = self.clean_all_files_for_notification(
+                    notification_id=notification_id, keep=keep
+                )
+                app.logger.info(
+                    f"Now clean all final files linked to the routing history ID {self.routing_history.id}"
+                )
+                statusF = self.clean_wfs_final_files(
+                    notification_id=notification_id, keep=keep
+                )
             else:
-                app.logger.info(f"{n_active_notifications} active notifications in routing history {self.routing_history.id} out of {len(self.routing_history.notification_states)}.")
-                app.logger.info(f"Cleaning only files linked to notification ID {notification_id} in routing history {self.routing_history.id}.")
-                statusF = self.clean_all_files_for_notification(notification_id=notification_id, keep=keep)
-        app.logger.info(f"File cleanup status: {statusF['status']}, Message: {statusF['message']}")
+                app.logger.info(
+                    f"{n_active_notifications} active notifications in routing history {self.routing_history.id} out of {len(self.routing_history.notification_states)}."
+                )
+                app.logger.info(
+                    f"Cleaning only files linked to notification ID {notification_id} in routing history {self.routing_history.id}."
+                )
+                statusF = self.clean_all_files_for_notification(
+                    notification_id=notification_id, keep=keep
+                )
+        app.logger.info(
+            f"File cleanup status: {statusF['status']}, Message: {statusF['message']}"
+        )
 
         if not dryRun:
             # Set the notification to deleted
-            if n_active_notifications > 0: # The if condition is for sanity check. We should have already returned if there are no active notifications
+            if n_active_notifications > 0:  # The if condition is for sanity check. We should have already returned if there are no active notifications
                 app.logger.info(f"Setting notification {notification_id} to deleted in routing history")
                 now_utc = datetime.now(timezone.utc).isoformat()
-                self.routing_history.add_notification_state(statusF['status'], notification_id, deleted=True, deleted_date=now_utc)
+                self.routing_history.add_notification_state(
+                    statusF["status"],
+                    notification_id,
+                    deleted=True,
+                    deleted_date=now_utc,
+                )
             # Add a tombstone state to workflow states
             if deletion_reason:
                 message = deletion_reason
             else:
                 message = f"Notification {notification_id} deleted as part of cleanup with status {statusF['status']}"
-            self.routing_history.add_workflow_state("tombstone", "server, store, jper", notification_id=notification_id,
-                    status=statusF['status'], message=message, log_url=self.airflow_log_location)
+            # Add list of files to the above message and pass it along to the tombstone
+            for k, v in statusF['cleanup_files'].items():
+                message += f". Deletion status for :::: {k} files : ["
+                for f_name in v:
+                    message += f"{f_name}, "
+                message += "]"
+            app.logger.info(message)
+            print(f"Clean up files status : {statusF['cleanup_files']}")
+            self.routing_history.add_workflow_state(
+                "tombstone",
+                "server, store, jper",
+                notification_id=notification_id,
+                status=statusF["status"],
+                message=message,
+                log_url=self.airflow_log_location,
+            )
             self.routing_history.save()
 
-        return { 'status': "success", 'message': f"Cleaned up routing history ID {self.routing_history.id}" }
+        return {
+            "status": "success",
+            "message": f"Cleaned up routing history ID {self.routing_history.id}",
+        }

--- a/airflow/dags/jper_scheduler/utils.py
+++ b/airflow/dags/jper_scheduler/utils.py
@@ -1,11 +1,19 @@
+import json
+import os
+import shutil
+import tarfile
 import uuid
-import os, shutil, zipfile, tarfile
-import esprit
+import zipfile
 from urllib.parse import urlparse
+
+import esprit
+import requests
 from octopus.core import app
 from octopus.modules.store import store
+
 from service import models
 from service.models.routing_history import RoutingHistory
+
 
 # Utility function for processftp
 # Function for the checkftp to unzip and move stuff up then zip again in incoming packages
@@ -16,7 +24,7 @@ def zip(src, dst):
     for dirname, subdirs, files in os.walk(src):
         for filename in files:
             absname = os.path.abspath(os.path.join(dirname, filename))
-            arcname = absname[len(abs_src) + 1:]
+            arcname = absname[len(abs_src) + 1 :]
             zf.write(absname, arcname)
     zf.close()
     app.logger.info(f"Created zip file for {src} at {dst}")
@@ -30,11 +38,11 @@ def pkgformat(src):
     app.logger.debug(f"Finding package format for source {src}")
     pkg_fmt = "unknown"
     for fl in os.listdir(src):
-        if '.xml' in fl:
+        if ".xml" in fl:
             filepath = os.path.join(src, fl)
             app.logger.debug(f"Finding package format for file {filepath}")
             try:
-                with open(filepath, 'r') as f:
+                with open(filepath, "r") as f:
                     for line in f:
                         if "//NLM//DTD Journal " in line:
                             pkg_fmt = "https://datahub.deepgreen.org/FilesAndJATS"
@@ -91,37 +99,45 @@ def flatten(destination, depth=None):
     has_xml = False
     stem = None
     for fl in os.listdir(depth):
-        if 'article_metadata.xml' in fl:
+        if "article_metadata.xml" in fl:
             # De Gruyter provides a second .xml sometimes, sigh.
-            os.remove(depth + '/' + fl)
+            os.remove(depth + "/" + fl)
             continue
-        if not has_xml and '.xml' in fl:
-            app.logger.debug(f"Flattening xml file {fl} found in dir {depth} as a new notification")
+        if not has_xml and ".xml" in fl:
+            app.logger.debug(
+                f"Flattening xml file {fl} found in dir {depth} as a new notification"
+            )
             has_xml = True
-            words = destination.split('/')
-            stem = words[-1] + '/' + os.path.splitext(fl)[0]
-            new_loc = destination + '/' + stem
+            words = destination.split("/")
+            stem = words[-1] + "/" + os.path.splitext(fl)[0]
+            new_loc = destination + "/" + stem
             if not os.path.exists(new_loc):
                 os.makedirs(new_loc)
-                app.logger.debug(f"Created new location {new_loc} within {destination} for file {fl}")
+                app.logger.debug(
+                    f"Created new location {new_loc} within {destination} for file {fl}"
+                )
     # 2019-11-18 TD : end of recursion stop marker search
     #
     for fl in os.listdir(depth):
         # 2019-11-18 TD : Additional check for 'has_xml' (the stop marker)
         # if '.zip' in fl: # or '.tar' in fl:
-        if not has_xml and '.zip' in fl:  # or '.tar' in fl:
+        if not has_xml and ".zip" in fl:  # or '.tar' in fl:
             app.logger.debug(f"Extracting zip file {fl} found in dir {depth}")
-            extracted = extract(depth + '/' + fl, depth)
+            extracted = extract(depth + "/" + fl, depth)
             if extracted:
-                os.remove(depth + '/' + fl)
-                app.logger.debug(f"Calling flatten to extract notification from {depth + '/' + fl}")
+                os.remove(depth + "/" + fl)
+                app.logger.debug(
+                    f"Calling flatten to extract notification from {depth + '/' + fl}"
+                )
                 flatten(destination, depth)
         # 2019-11-18 TD : Additional check for 'has_xml' (the stop marker)
         # elif os.path.isdir(depth + '/' + fl):
-        elif os.path.isdir(depth + '/' + fl) and not has_xml:
+        elif os.path.isdir(depth + "/" + fl) and not has_xml:
             app.logger.debug(f"Found directory at {depth + '/' + fl}")
-            app.logger.debug(f"Calling flatten to extract notification from {depth + '/' + fl}")
-            flatten(destination, depth + '/' + fl)
+            app.logger.debug(
+                f"Calling flatten to extract notification from {depth + '/' + fl}"
+            )
+            flatten(destination, depth + "/" + fl)
         else:
             try:
                 # shutil.move(depth + '/' + fl, destination)
@@ -139,6 +155,7 @@ def flatten(destination, depth=None):
             except:
                 pass
 
+
 # Utility function to set task name
 def set_task_name(map_index, task_str):
     task_name = f"{map_index} {task_str}"
@@ -147,13 +164,14 @@ def set_task_name(map_index, task_str):
         sanitised_name = f"{task_name[:245]} ..."
     return sanitised_name
 
+
 # Utility function to get log url
 def get_log_url(context):
-    full_log_url = context['task_instance'].log_url
+    full_log_url = context["task_instance"].log_url
     query_params = full_log_url.split("&")
     query_params_filtered = []
     for q in query_params:
-        if not 'base_date' in q:
+        if not "base_date" in q:
             query_params_filtered.append(q)
     log_url = "&".join(query_params_filtered)
     parsed_url = urlparse(log_url)
@@ -161,56 +179,75 @@ def get_log_url(context):
     app.logger.info(f"Log for this job : {new_path}")
     return new_path
 
-def get_notifications_for(conn=None, notification_id=None, publisher_id=None, upto=None, since=None, scroll_id=None, page=1, page_size=10000):
+
+def scroll_next_fixed(conn, scroll_id, keepalive="2m"):
+    """Drop-in replacement for esprit.raw.scroll_next that sends scroll_id in the body."""
+    url = esprit.raw.elasticsearch_url(conn, endpoint="_search/scroll", omit_index=True)
+    body = {"scroll": keepalive, "scroll_id": scroll_id}
+    resp = {}
+    try:
+        resp = requests.post(
+            url,
+            data=json.dumps(body),
+            headers={"Content-Type": "application/json"},
+            auth=conn.auth if hasattr(conn, "auth") else None,
+        )
+    except requests.exceptions.ConnectionError as e:
+        app.logger.error(f"Connection error: {e}")
+        resp = {}
+    except Exception as e:
+        app.logger.error(f"Unexpected error: {e}")
+        resp = {}
+    return resp
+
+
+def get_notifications_for(
+    conn=None,
+    notification_id=None,
+    publisher_id=None,
+    upto=None,
+    since=None,
+    scroll_id=None,
+    page=1,
+    page_size=10000,
+):
     if notification_id:
         # Fetch notifications from Elasticsearch for the given notification ID
         qr = {
             "size": page_size,
-            "query": {
-                "bool": {
-                    "must": [
-                        {"term": {"id.exact": notification_id}}
-                    ]
-                }
-            }
+            "query": {"bool": {"must": [{"term": {"id.exact": notification_id}}]}},
         }
-        response = esprit.raw.initialise_scroll(conn, query=qr, keepalive='2m')
+        response = esprit.raw.initialise_scroll(conn, query=qr, keepalive="10m")
     else:
         # Fetch notifications from Elasticsearch for the given date range and pagination parameters
         qr = {
             "size": page_size,
             "query": {
                 "bool": {
-                    "filter": {
-                        "range": {
-                            "created_date": {
-                                "gte": since,
-                                "lte": upto
-                            }
-                        }
-                    }
-                    
+                    "filter": {"range": {"created_date": {"gte": since, "lte": upto}}}
                 }
             },
-            "sort": [{"created_date": {"order": "desc"}}]
+            "sort": [{"created_date": {"order": "asc"}}],
+            "stored_fields": []
         }
         if publisher_id:
             qr["query"]["bool"] = {
-                "must": [
-                    {"term": {"provider.id.exact": publisher_id}}
-                ]
+                "must": [{"term": {"provider.id.exact": publisher_id}}]
             }
 
-        if page == 1: # Initial query to fetch the first page and get the scroll_id for pagination
-            response = esprit.raw.initialise_scroll(conn, query=qr, keepalive='2m')
+        if (
+            page == 1
+        ):  # Initial query to fetch the first page and get the scroll_id for pagination
+            response = esprit.raw.initialise_scroll(conn, query=qr, keepalive="2m")
         else:
-            response = esprit.raw.scroll_next(conn, scroll_id=scroll_id, keepalive='2m')
+            response = scroll_next_fixed(conn, scroll_id=scroll_id, keepalive="10m")
     data = response.json()
     return data
 
+
 def utils_log_routing_history(rh):
     app.logger.debug("Begin Routing History")
-    app.logger.debug(f'Routing History> {rh.__dict__["data"]}')
+    app.logger.debug(f"Routing History> {rh.__dict__['data']}")
     app.logger.debug("Routing History> individual workflow states :")
     for state in rh.workflow_states:
         app.logger.debug(f"{state['action']} > {state}")
@@ -222,35 +259,43 @@ def utils_log_routing_history(rh):
         app.logger.debug(f"{state['location_type']} > {state}")
     app.logger.debug("END Routing History")
 
+
 def create_routing_history_record(note_index, notification_id, log_url=None):
-    app.logger.info(f"Creating routing history record for notification ID {notification_id}")
+    app.logger.info(
+        f"Creating routing history record for notification ID {notification_id}"
+    )
 
     obj = None
     matches = 0
     note_state = "success"
-    if note_index.startswith('jper-routed'):
+    if note_index.startswith("jper-routed"):
         app.logger.info(f"Processing routed notification id: {notification_id}")
         obj = models.RoutedNotification.pull(notification_id)
         if obj and obj.repositories:
             matches = len(obj.repositories)
-    elif note_index.startswith('jper-failed'):
+    elif note_index.startswith("jper-failed"):
         app.logger.info(f"Processing failed notification id: {notification_id}")
         obj = models.FailedNotification.pull(notification_id)
         note_state = "failure"
 
-    metadata = obj.metadata if obj and hasattr(obj, 'metadata') else {}
-    doi = metadata.get('doi', 'None')
-    app.logger.info(f"Notification ID {notification_id} has DOI {doi} and matches {matches} repositories")
+    metadata = obj.metadata if obj and hasattr(obj, "metadata") else {}
+    doi = metadata.get("doi", "None")
+    app.logger.info(
+        f"Notification ID {notification_id} has DOI {doi} and matches {matches} repositories"
+    )
 
     rh = RoutingHistory()
     rh.id = uuid.uuid4().hex
-    try:
-        acc = models.Account().pull(obj.provider.id)
-    except AttributeError as e:
-        acc = models.Account().pull(obj.provider_id)
-    except Exception as e:
-        app.logger.debug(f"Error pulling account for provider id {obj.provider_id} : {str(e)}")
-        acc = None
+    acc = None
+    if obj:
+        try:
+            acc = models.Account().pull(obj.provider.id)
+        except AttributeError as e:
+            acc = models.Account().pull(obj.provider_id)
+        except Exception as e:
+            app.logger.debug(
+                f"Error pulling account for provider id {obj.provider_id} : {str(e)}"
+            )
     if acc:
         rh.publisher_id = acc.id if acc else None
         rh.publisher_email = acc.email if acc else None
@@ -270,29 +315,55 @@ def create_routing_history_record(note_index, notification_id, log_url=None):
             print("Username attribute error")
             rh.sftp_username = ""
     app.logger.debug(f"Publisher : {rh.publisher_id}, {rh.publisher_email}")
-    app.logger.debug(f"SFTP info : URL {rh.sftp_server_url}, Port {rh.sftp_server_port}, Username {rh.sftp_username}")
+    app.logger.debug(
+        f"SFTP info : URL {rh.sftp_server_url}, Port {rh.sftp_server_port}, Username {rh.sftp_username}"
+    )
     rh.original_file_location = "None"
     rh.final_file_locations = []
-    rh.notification_states = [{
-        "status": note_state,
-        "notification_id": notification_id,
-        "doi": doi,
-        "number_matched_repositories": matches
-    }]
-    rh.add_workflow_state(action='New RH for old notification', file_location="None", notification_id=notification_id,
-                                        status="success", message="New routing history for old notification", log_url=log_url)
+    rh.notification_states = [
+        {
+            "status": note_state,
+            "notification_id": notification_id,
+            "doi": doi,
+            "number_matched_repositories": matches,
+        }
+    ]
+    rh.add_workflow_state(
+        action="New RH for old notification",
+        file_location="None",
+        notification_id=notification_id,
+        status="success",
+        message="New routing history for old notification",
+        log_url=log_url,
+    )
 
     if store.StoreFactory.get().exists(notification_id):
-        app.logger.info(f"Found record in store. Adding file locations to routing history for notification id: {notification_id}")
+        app.logger.info(
+            f"Found record in store. Adding file locations to routing history for notification id: {notification_id}"
+        )
         store_files = store.StoreFactory.get().list_file_paths(notification_id)
         for index, s_file in enumerate(store_files):
             rh.add_final_file_location("store", s_file)
-            rh.add_workflow_state(action=f"Store file {index}", file_location=s_file, notification_id=notification_id,
-                                status='success', message='Reprocessed old notification, added file locations from store', log_url=log_url)
+            rh.add_workflow_state(
+                action=f"Store file {index}",
+                file_location=s_file,
+                notification_id=notification_id,
+                status="success",
+                message="Reprocessed old notification, added file locations from store",
+                log_url=log_url,
+            )
     else:
-        app.logger.info(f"No record found in store for notification id: {notification_id}. Setting file location to None.")
-        rh.add_workflow_state(action=f"No Store file", file_location="None", notification_id=notification_id,
-                                status='success', message='Reprocessed old notification, no file location found in store', log_url=log_url)
+        app.logger.info(
+            f"No record found in store for notification id: {notification_id}. Setting file location to None."
+        )
+        rh.add_workflow_state(
+            action=f"No Store file",
+            file_location="None",
+            notification_id=notification_id,
+            status="success",
+            message="Reprocessed old notification, no file location found in store",
+            log_url=log_url,
+        )
 
     rh.save()
     # return rh

--- a/service/templates/delete_notifications/index/_form.html
+++ b/service/templates/delete_notifications/index/_form.html
@@ -32,11 +32,11 @@
                 </li>
                 <li class="form-fields__item--text">
                     <label>
-                        <span class="form-fields__label-text" style="width: 35%">Publisher ID</span>
-                        <select name="publisher_id">
-                            <option value="" {% if not publisher_id %}selected{% endif %}>Filter by Publisher ID</option>
-                            {% for val in publisher_ids %}
-                                <option value="{{ val }}" {% if publisher_id == val %}selected{% endif %}>{{ val }}</option>
+                        <span class="form-fields__label-text">Publisher Email</span>
+                        <select name="publisher_email">
+                            <option value="" {% if not publisher_email %}selected{% endif %}>Filter by Publisher emails</option>
+                            {% for val in publisher_emails %}
+                                <option value="{{ val }}" {% if publisher_email == val %}selected{% endif %}>{{ val }}<z/option>
                             {% endfor %}
                         </select>
                     </label>

--- a/service/templates/delete_notifications/index/_message.html
+++ b/service/templates/delete_notifications/index/_message.html
@@ -5,9 +5,9 @@
         <dt>Delete notifications between:</dt>
         <dd>{{ brom }} and {{ upto }}</dd>
       {% endif %}
-      {% if publisher_id %}
-        <dt>Publisher ID:</dt>
-        <dd>{{ publisher_id }}</dd>
+      {% if publisher_email %}
+        <dt>Publisher email:</dt>
+        <dd>{{ publisher_email }}</dd>
       {% endif %}
       {% if status_values|length > 0 %}
         <dt>Status:</dt>

--- a/service/views/delete_notifications.py
+++ b/service/views/delete_notifications.py
@@ -26,12 +26,14 @@ def index():
                                  param='upto')
 
     publisher_ids = models.RoutingHistory.get_all_publisher_ids()
+    pub_ids_reversed = dict((v,k) for k,v in publisher_ids.items())
+    publisher_emails = models.RoutingHistory.get_all_publisher_emails()
 
     notification_id = ""
 
     if request.method == 'GET':
         return render_template('delete_notifications/index.html', publisher_id=None,
-                               publisher_ids=publisher_ids, since=default_from, upto=default_upto,
+                               publisher_emails=publisher_emails, since=default_from, upto=default_upto,
                                status_values=[], notification_id=notification_id)
 
     # POST
@@ -39,7 +41,9 @@ def index():
         "from": default_from,
         "upto": default_upto,
         "publisher_id": None,
+        "publisher_email": None,
         "publisher_ids": publisher_ids,
+        "publisher_emails": publisher_emails,
         "notification_id": notification_id,
         "status_values": [],
         "rerouting": None,
@@ -59,10 +63,11 @@ def index():
         return call_airflow_dag_to_delete_notifications(x)
 
     # Get publisher_id
-    publisher_id = request.values.get('publisher_id')
-    if publisher_id == '':
-        publisher_id = None
-    x['publisher_id'] = publisher_id
+    publisher_email = request.values.get('publisher_email')
+    if publisher_email == '':
+        publisher_email = None
+    x['publisher_email'] = publisher_email
+    x['publisher_id'] = pub_ids_reversed[publisher_emails[publisher_email]]
 
     # status values
     accepted_status_values = ['success-routed', 'success-no-matches', 'failure']
@@ -81,7 +86,7 @@ def index():
     except ValueError as e:
         flash(f"Error validating 'from' date: {e}")
         return render_template('delete_notifications/index.html', publisher_id=x['publisher_id'],
-                        publisher_ids=x['publisher_ids'], since=since, upto=x['upto'],
+                        publisher_emails=x['publisher_emails'], since=since, upto=x['upto'],
                         status_values=x['status_values'])
     x['from'] = since
 
@@ -94,7 +99,7 @@ def index():
     except ValueError as e:
         flash(f"Error validating 'upto' date: {e}")
         return render_template('delete_notifications/index.html', publisher_id=x['publisher_id'],
-                        publisher_ids=x['publisher_ids'], since=x['from'], upto=upto,
+                        publisher_emails=x['publisher_emails'], since=x['from'], upto=upto,
                         status_values=x['status_values'])
     x['upto'] = upto
     # if is_newer(upto, default_upto):
@@ -117,8 +122,8 @@ def call_airflow_dag_to_delete_notifications(x):
     else:
         flash("Airflow deletion user or password not set - cannot call deletion DAG. Please" \
         " request system administrator to check configuration.")
-        return render_template('delete_notifications/index.html', publisher_id=x['publisher_id'],
-                        publisher_ids=x['publisher_ids'], since=x['from'], upto=x['upto'],
+        return render_template('delete_notifications/index.html', publisher_email=x['publisher_email'],
+                        publisher_emails=x['publisher_emails'], since=x['from'], upto=x['upto'],
                         status_values=x['status_values'])
     headers = {
         "Content-Type": "application/json",
@@ -133,8 +138,8 @@ def call_airflow_dag_to_delete_notifications(x):
         }
     else:
         data = {
-            "conf": {"upto": x['upto'], "from": x['from'], "status_values": x['status_values'], "publisher_id": x['publisher_id']},
-            "note": f"User request to delete notifications between {x['from']} and {x['upto']} for publisher_id {x['publisher_id']} with status values {x['status_values']}"
+            "conf": {"upto": x['upto'], "from": x['from'], "status_values": x['status_values'], "publisher_id": x['publisher_id'], "publisher_email": x['publisher_email']},
+            "note": f"User request to delete notifications between {x['from']} and {x['upto']} for publisher_id {x['publisher_id']} with status values {x['status_values']} and publisher_email {x['publisher_email']}"
         }
     # Always needed
     data['conf']['rerouting'] = x['rerouting']
@@ -150,8 +155,8 @@ def call_airflow_dag_to_delete_notifications(x):
             flash(f"Successfully triggered Airflow DAG to delete notifications between {x['from']} and {x['upto']}.")
     else:
         flash(f"Failed to trigger Airflow DAG. Status code: {r.status_code}, response: {r.text}")
-        return render_template('delete_notifications/deletion_sent.html', publisher_id=x['publisher_id'],
-                              publisher_ids=x['publisher_ids'], since=x['from'], upto=x['upto'],
+        return render_template('delete_notifications/deletion_sent.html', publisher_email=x['publisher_email'],
+                              publisher_emails=x['publisher_emails'], since=x['from'], upto=x['upto'],
                               status_values=x['status_values'])
     print(f"Airflow deletion request: {r.request.body}")
     print(f"Airflow deletion url: {r.url}")
@@ -159,6 +164,6 @@ def call_airflow_dag_to_delete_notifications(x):
     if jper_url.endswith('/'):
         jper_url = jper_url[:-1]
     airflow_display_url = f"{jper_url}/airflow/dags/{deletion_dag}/graph"
-    return render_template('delete_notifications/deletion_sent.html', publisher_id=x['publisher_id'],
-                           publisher_ids=x['publisher_ids'], since=x['from'], upto=x['upto'],
+    return render_template('delete_notifications/deletion_sent.html', publisher_email=x['publisher_email'],
+                           publisher_emails=x['publisher_emails'], since=x['from'], upto=x['upto'],
                            status_values=x['status_values'], airflow_url=airflow_display_url)


### PR DESCRIPTION
First round of multiple updates for the following

1. Some code cleanup to use \' and \" more consistently (done by IDE)
2. Add method to make Open Search scroll use put instead of get of the requests module. This is the way going forward and will need to be ported into esprit.
3. Move to use publisher email instead of publisher ID for selecting notifications to delete.
4. Keep track of files that were processed and add into the message of the tombstone state
5. Track the deletion requests by writing them out into a json file which is updated as needed. This can also be used to track the current status in the jper web page.